### PR TITLE
gsapの導入とheaderをアニメーションさせた

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5897,6 +5897,12 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
+    "gsap": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.6.0.tgz",
+      "integrity": "sha512-0P3syv1TmYr+A/VZ8UMFzw+s0XoaKSzzDFs8NqkXiJTXI4E/VTi0zRjPgxaPBpiUPPycgRnFjLDe0Tb4dRRf+w==",
+      "dev": true
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint": "^7.18.0",
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-prettier": "^3.3.1",
+    "gsap": "^3.6.0",
     "imagemin-cli": "^6.0.0",
     "imagemin-gifsicle": "^7.0.0",
     "imagemin-keep-folder": "^5.3.2",

--- a/src/_include/_header.ejs
+++ b/src/_include/_header.ejs
@@ -1,0 +1,3 @@
+<header class="c-header">
+  <h1>title</h1>
+</header>

--- a/src/_include/_meta.ejs
+++ b/src/_include/_meta.ejs
@@ -2,6 +2,5 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="format-detection" content="telephone=no">
 <link rel="stylesheet" href="/css/style.css">
-<script src="/js/index.js"></script>
 <title><%= pagetitle %>sample gsap</title>
 <meta name="description" content="<%= description %>">

--- a/src/ejs/index.ejs
+++ b/src/ejs/index.ejs
@@ -8,6 +8,7 @@
 <% include ../_include/_meta.ejs %>
 </head>
 <body>
+<% include ../_include/_header.ejs %>
 <!-- /content -->
 <div class="l-content">
   <div class="l-inner">
@@ -16,6 +17,6 @@
     </p>
   </div><!-- /inner -->
 </div><!-- /content -->
-
+<script src="/js/index.js"></script>
 </body>
 </html>

--- a/src/js/common/_test.js
+++ b/src/js/common/_test.js
@@ -1,3 +1,0 @@
-export function init() {
-    console.log('hello world');
-}

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,3 +1,12 @@
-import * as test from './common/_test';
+import { gsap } from 'gsap';
 
-test.init();
+const tween = gsap.to('header', {
+    duration: 0.5,
+    paused: true,
+    ease: 'power2.out',
+    top: 0,
+});
+
+const header = document.getElementsByClassName('c-header')[0];
+console.log(header);
+header.addEventListener('click', () => tween.play());

--- a/src/scss/Object/Component/c-header.scss
+++ b/src/scss/Object/Component/c-header.scss
@@ -1,0 +1,18 @@
+.c-header {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  background: #068dc9;
+  cursor: pointer;
+  color: #ffffff;
+  text-align: center;
+  position: absolute;
+  top: 100px;
+  left: 50%;
+  transform: translate(-50%);
+}
+
+.c-eader h1 {
+  font-size: 48px;
+  opacity: 0;
+}


### PR DESCRIPTION
## 概要
gsapの導入とheaderをアニメーションさせた

## 変更内容
 - `npm install --save-dev gsap`でgsap導入
 - ejsにheaderを追加、スタイル追加
 - jsにheaderのアニメーション追加

## 参考サイト
[フロントエンドから始めるアニメーション最強のライブラリGSAP3を手に入れよう](https://ics.media/entry/200805/)